### PR TITLE
fix: bn allocator exhaustion [LIVE-34694]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zcash"
-version = "3.8.0"
+version = "3.8.3"
 dependencies = [
  "arrayvec",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zcash"
-version = "3.8.5"
+version = "3.8.6"
 dependencies = [
  "arrayvec",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zcash"
-version = "3.8.3"
+version = "3.8.4"
 dependencies = [
  "arrayvec",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "zcash"
-version = "3.8.4"
+version = "3.8.5"
 dependencies = [
  "arrayvec",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ledger_device_sdk = { version = "1.*", features = ["sys"] }
 
 [package]
 name = "zcash"
-version = "3.8.4"
+version = "3.8.5"
 authors = ["Ledger"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ledger_device_sdk = { version = "1.*", features = ["sys"] }
 
 [package]
 name = "zcash"
-version = "3.8.5"
+version = "3.8.6"
 authors = ["Ledger"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ledger_device_sdk = { version = "1.*", features = ["sys"] }
 
 [package]
 name = "zcash"
-version = "3.8.3"
+version = "3.8.4"
 authors = ["Ledger"]
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ ledger_device_sdk = { version = "1.*", features = ["sys"] }
 
 [package]
 name = "zcash"
-version = "3.8.0"
+version = "3.8.3"
 authors = ["Ledger"]
 edition = "2024"
 

--- a/ledger_zcash_crypto/Cargo.toml
+++ b/ledger_zcash_crypto/Cargo.toml
@@ -17,3 +17,7 @@ pasta_curves = { version = "0.5", default-features = false }
 default = ["montgomery_fallback"]
 
 montgomery_fallback = []
+
+# Enables the Ledger SDK on-device unit-test framework (TestType / sdk_test_runner).
+# Required when running `cargo test` for this crate under Speculos.
+unit_test = ["ledger_device_sdk/unit_test"]

--- a/ledger_zcash_crypto/src/lib.rs
+++ b/ledger_zcash_crypto/src/lib.rs
@@ -1,4 +1,8 @@
 #![no_std]
+#![feature(custom_test_frameworks)]
+#![cfg_attr(test, no_main)]
+#![cfg_attr(test, test_runner(ledger_device_sdk::testing::sdk_test_runner))]
+#![cfg_attr(test, reexport_test_harness_main = "test_main")]
 
 extern crate alloc;
 
@@ -549,4 +553,18 @@ fn encode_pallas_point_bytes(x_be: &[u8; 32], sign: u32) -> [u8; 32] {
     bytes::reverse_copy(&mut x_le, x_be);
     x_le[31] |= ((sign & 1) as u8) << 7;
     x_le
+}
+
+// On-device unit-test entry point. The C runtime provided by the Ledger SDK
+// calls `sample_main`, which here simply runs the generated test harness.
+#[cfg(test)]
+#[unsafe(no_mangle)]
+fn sample_main() {
+    test_main();
+}
+
+#[cfg(test)]
+#[panic_handler]
+fn test_panic_handler(info: &core::panic::PanicInfo) -> ! {
+    ledger_device_sdk::testing::test_panic(info)
 }

--- a/ledger_zcash_crypto/src/montgomery.rs
+++ b/ledger_zcash_crypto/src/montgomery.rs
@@ -45,22 +45,12 @@ const PALLAS_SCALAR_R2_U64X4: [u64; 4] = [
 // Montgomery -n^{-1} mod 2^64 derived from the low limb of the scalar modulus.
 const PALLAS_SCALAR_INV: u64 = 0x8c46eb20ffffffff;
 
-#[cfg(feature = "montgomery_fallback")]
 pub(crate) fn repr_to_montgomery_u64x4(
     repr: &[u8; 32],
     modulus_param: CurveDomainParam,
     malformed_error: Error,
 ) -> Result<[u64; 4], Error> {
     repr_to_montgomery_u64x4_pasta(repr, modulus_param, malformed_error)
-}
-
-#[cfg(not(feature = "montgomery_fallback"))]
-pub(crate) fn repr_to_montgomery_u64x4(
-    repr: &[u8; 32],
-    modulus_param: CurveDomainParam,
-    malformed_error: Error,
-) -> Result<[u64; 4], Error> {
-    repr_to_montgomery_u64x4_ledger_sdk(repr, modulus_param, malformed_error)
 }
 
 pub(crate) fn byte_to_fp(bytes: &[u64; 4]) -> Fp {
@@ -175,6 +165,7 @@ pub(crate) fn montgomery_reduce_u64x8(limbs: [u64; 8], modulus: [u64; 4], inv: u
 }
 
 #[cfg(not(feature = "montgomery_fallback"))]
+#[allow(dead_code)]
 fn repr_to_montgomery_u64x4_ledger_sdk(
     repr: &[u8; 32],
     modulus_param: CurveDomainParam,
@@ -206,7 +197,6 @@ fn repr_to_montgomery_u64x4_ledger_sdk(
     Ok(repr_to_u64x4(&mont_le))
 }
 
-#[cfg(feature = "montgomery_fallback")]
 fn repr_to_montgomery_u64x4_pasta(
     repr: &[u8; 32],
     modulus_param: CurveDomainParam,
@@ -253,10 +243,13 @@ fn mac_u64(a: u64, b: u64, c: u64, carry: u64) -> (u64, u64) {
 // NOTE: These tests can only be run manually by calling test functions from device code.
 #[cfg(test)]
 mod tests {
-    use super::{repr_to_montgomery_u64x4_ledger_sdk, repr_to_montgomery_u64x4_pasta};
+    #[cfg(not(feature = "montgomery_fallback"))]
+    use super::repr_to_montgomery_u64x4_ledger_sdk;
+    use super::repr_to_montgomery_u64x4_pasta;
     use crate::Error;
     use ledger_device_sdk::ecc::math::CurveDomainParam;
 
+    #[cfg(not(feature = "montgomery_fallback"))]
     #[test]
     fn test_repr_to_montgomery_u64x4() {
         let mut repr = [0u8; 32];

--- a/ledger_zcash_crypto/src/orchard.rs
+++ b/ledger_zcash_crypto/src/orchard.rs
@@ -15,9 +15,10 @@ use crate::{
     Error, ORCHARD_ESK_DOMAIN_SEPARATOR, ORCHARD_PSI_DOMAIN_SEPARATOR,
     ORCHARD_RCM_DOMAIN_SEPARATOR, PRF_EXPAND_BYTES,
     bytes::reverse_copy,
-    pallas_base_from_repr, pallas_basepoint_mul, pallas_point_add, pallas_point_from_bytes,
+    pallas_base_from_repr, pallas_basepoint_mul, pallas_point_from_bytes,
     pallas_point_to_bytes, pallas_scalar_from_repr, prf_expand_with_domain_separator_and_inputs,
-    sinsemilla::{extract_p, sinsemilla_short_commit, sinsemilla_short_commit_point},
+    redpallas::point_from_sdk_point,
+    sinsemilla::{extract_p_pallas, sinsemilla_short_commit, sinsemilla_short_commit_point},
     to_pallas_base_bytes, to_pallas_scalar_bytes,
 };
 
@@ -114,14 +115,16 @@ pub fn spend_nullifier_bytes(
     let nullifier_point = if bool::from(nullifier_scalar.is_zero()) {
         cm
     } else {
-        let nullifier_k = pallas_basepoint_mul(
+        // Convert the SDK basepoint-mul result to pallas::Point and add in pure Rust,
+        // keeping the total Bn allocation to 2 slots (just the scalar-mul EcPoint).
+        let nullifier_k_ec = pallas_basepoint_mul(
             &ORCHARD_NULLIFIER_K_BASEPOINT_BYTES,
             &scalar_bytes_be(&nullifier_scalar),
         )?;
-        pallas_point_add(&nullifier_k, &cm)?
+        point_from_sdk_point(&nullifier_k_ec)? + cm
     };
 
-    Ok(extract_p(&nullifier_point)?.to_repr())
+    Ok(extract_p_pallas(&nullifier_point).to_repr())
 }
 
 pub fn note_commitment_bytes(
@@ -501,7 +504,7 @@ fn note_commitment_point(
     value: u64,
     rho: &pallas::Base,
     rseed: &[u8; HASH_SIZE],
-) -> Result<ledger_device_sdk::ecc::math::EcPoint, Error> {
+) -> Result<pallas::Point, Error> {
     let psi = orchard_psi(rseed, rho)?;
     let rcm = orchard_rcm(rseed, rho)?;
     let rcm = pallas_scalar_from_repr(rcm)?;

--- a/ledger_zcash_crypto/src/redpallas.rs
+++ b/ledger_zcash_crypto/src/redpallas.rs
@@ -218,19 +218,26 @@ pub fn spendauth_randomized_signing_key(
     let scalar_bytes_be = canonical_scalar_bytes_be(&scalar_bytes_le)?;
     let randomizer_bytes_be = canonical_scalar_bytes_be(&randomizer_bytes_le)?;
 
-    let scalar = Bn::alloc_init(&scalar_bytes_be)?;
-    let randomizer = Bn::alloc_init(&randomizer_bytes_be)?;
-    let mut order = Bn::alloc(32)?;
-    CurvesId::Pallas.domain_parameter_bn(CurveDomainParam::Order, &mut order)?;
+    // Scope the Bn objects so they are freed before calling spendauth_signing_key.
+    // Without this block, scalar/randomizer/order/randomized remain alive across
+    // the tail call, which pushes the concurrent Bn count past the SDK pool limit
+    // and causes Bn::alloc inside spendauth_signing_key to return CxError.
+    let randomized_bytes_le = {
+        let scalar = Bn::alloc_init(&scalar_bytes_be)?;
+        let randomizer = Bn::alloc_init(&randomizer_bytes_be)?;
+        let mut order = Bn::alloc(32)?;
+        CurvesId::Pallas.domain_parameter_bn(CurveDomainParam::Order, &mut order)?;
 
-    let randomized = Bn::alloc(32)?;
-    randomized.mod_add(&scalar, &randomizer, &order)?;
+        let randomized = Bn::alloc(32)?;
+        randomized.mod_add(&scalar, &randomizer, &order)?;
 
-    let mut randomized_bytes_be = [0u8; 32];
-    randomized.export(&mut randomized_bytes_be)?;
+        let mut randomized_bytes_be = [0u8; 32];
+        randomized.export(&mut randomized_bytes_be)?;
 
-    let mut randomized_bytes_le = [0u8; 32];
-    reverse_copy(&mut randomized_bytes_le, &randomized_bytes_be);
+        let mut randomized_bytes_le = [0u8; 32];
+        reverse_copy(&mut randomized_bytes_le, &randomized_bytes_be);
+        randomized_bytes_le
+    };
 
     spendauth_signing_key(randomized_bytes_le)
 }

--- a/ledger_zcash_crypto/src/redpallas.rs
+++ b/ledger_zcash_crypto/src/redpallas.rs
@@ -480,3 +480,88 @@ fn encode_pallas_point_bytes(x_be: &[u8; 32], sign: u32) -> [u8; 32] {
     x_le[31] |= ((sign & 1) as u8) << 7;
     x_le
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ledger_device_sdk::testing::TestType;
+
+    /// Little-endian scalar encoding of a small `u8` value.
+    fn scalar_from_u8(n: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = n;
+        bytes
+    }
+
+    /// A full-width, non-trivial scalar guaranteed to be canonical: the most
+    /// significant little-endian byte is left at 0, so the value is < 2^248,
+    /// well below the Pallas scalar-field order.
+    fn wide_canonical_scalar(seed: u8) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        let mut i = 0;
+        while i < 31 {
+            bytes[i] = seed.wrapping_add(i as u8) | 1;
+            i += 1;
+        }
+        bytes
+    }
+
+    fn signing_keys_eq(a: &SpendAuthSigningKey, b: &SpendAuthSigningKey) -> bool {
+        <[u8; 32]>::from(a) == <[u8; 32]>::from(b)
+            && a.verification_key_bytes() == b.verification_key_bytes()
+    }
+
+    /// Randomizing with a zero randomizer must yield exactly the plain signing
+    /// key derived from the same scalar.
+    #[test_case]
+    const RANDOMIZE_WITH_ZERO_IS_IDENTITY: TestType = TestType {
+        modname: module_path!(),
+        name: "randomize_with_zero_is_identity",
+        f: || {
+            let scalar = scalar_from_u8(9);
+            let randomized = spendauth_randomized_signing_key(scalar, [0u8; 32]).map_err(|_| ())?;
+            let plain = spendauth_signing_key(scalar).map_err(|_| ())?;
+            if !signing_keys_eq(&randomized, &plain) {
+                return Err(());
+            }
+            Ok(())
+        },
+    };
+
+    /// `(scalar + randomizer)` with small operands stays below the field order,
+    /// so the randomized key must equal the signing key of the plain sum.
+    #[test_case]
+    const RANDOMIZE_MATCHES_SCALAR_SUM: TestType = TestType {
+        modname: module_path!(),
+        name: "randomize_matches_scalar_sum",
+        f: || {
+            // 5 + 7 = 12, all far below the field order => (a + r) mod q == a + r.
+            let randomized =
+                spendauth_randomized_signing_key(scalar_from_u8(5), scalar_from_u8(7))
+                    .map_err(|_| ())?;
+            let expected = spendauth_signing_key(scalar_from_u8(12)).map_err(|_| ())?;
+            if !signing_keys_eq(&randomized, &expected) {
+                return Err(());
+            }
+            Ok(())
+        },
+    };
+
+    /// Regression test for the Bn allocator exhaustion fix: with full-width
+    /// scalars the temporary `Bn` values allocated while computing the
+    /// randomized scalar must be freed before the tail call to
+    /// `spendauth_signing_key`. Otherwise the concurrent `Bn` count exceeds the
+    /// SDK pool limit and `Bn::alloc` inside `spendauth_signing_key` fails with
+    /// `CxError`, which surfaces here as an `Err`.
+    #[test_case]
+    const RANDOMIZE_WIDE_SCALARS_DOES_NOT_EXHAUST_BN_POOL: TestType = TestType {
+        modname: module_path!(),
+        name: "randomize_wide_scalars_does_not_exhaust_bn_pool",
+        f: || {
+            let scalar = wide_canonical_scalar(0x11);
+            let randomizer = wide_canonical_scalar(0x42);
+            spendauth_randomized_signing_key(scalar, randomizer).map_err(|_| ())?;
+            Ok(())
+        },
+    };
+}

--- a/ledger_zcash_crypto/src/redpallas.rs
+++ b/ledger_zcash_crypto/src/redpallas.rs
@@ -536,9 +536,8 @@ mod tests {
         name: "randomize_matches_scalar_sum",
         f: || {
             // 5 + 7 = 12, all far below the field order => (a + r) mod q == a + r.
-            let randomized =
-                spendauth_randomized_signing_key(scalar_from_u8(5), scalar_from_u8(7))
-                    .map_err(|_| ())?;
+            let randomized = spendauth_randomized_signing_key(scalar_from_u8(5), scalar_from_u8(7))
+                .map_err(|_| ())?;
             let expected = spendauth_signing_key(scalar_from_u8(12)).map_err(|_| ())?;
             if !signing_keys_eq(&randomized, &expected) {
                 return Err(());

--- a/ledger_zcash_crypto/src/redpallas.rs
+++ b/ledger_zcash_crypto/src/redpallas.rs
@@ -410,7 +410,7 @@ fn reduce_uniform_le_bytes_mod_pallas_order(uniform_le: &[u8; 64]) -> Result<[u8
     Ok(reduced_bytes_le)
 }
 
-fn point_from_sdk_point(point: &EcPoint) -> Result<pallas::Point, Error> {
+pub(crate) fn point_from_sdk_point(point: &EcPoint) -> Result<pallas::Point, Error> {
     let mut x_be = [0u8; 32];
     let mut y_be = [0u8; 32];
     point.export(&mut x_be, &mut y_be)?;
@@ -440,7 +440,7 @@ struct ProjectivePointLayout {
     z: pallas::Base,
 }
 
-fn projective_point(x: pallas::Base, y: pallas::Base, z: pallas::Base) -> pallas::Point {
+pub(crate) fn projective_point(x: pallas::Base, y: pallas::Base, z: pallas::Base) -> pallas::Point {
     debug_assert_eq!(
         core::mem::size_of::<ProjectivePointLayout>(),
         core::mem::size_of::<pallas::Point>(),
@@ -456,7 +456,7 @@ fn projective_point(x: pallas::Base, y: pallas::Base, z: pallas::Base) -> pallas
     unsafe { core::mem::transmute(ProjectivePointLayout { x, y, z }) }
 }
 
-fn base_from_canonical_repr_unchecked(repr: [u8; 32]) -> pallas::Base {
+pub(crate) fn base_from_canonical_repr_unchecked(repr: [u8; 32]) -> pallas::Base {
     let repr_u64x4 = repr_to_u64x4(&repr);
     let (modulus, r2, inv) = pallas_montgomery_params(CurveDomainParam::Field);
     let wide = mul_u64x4(&repr_u64x4, &r2);

--- a/ledger_zcash_crypto/src/sinsemilla.rs
+++ b/ledger_zcash_crypto/src/sinsemilla.rs
@@ -1,8 +1,9 @@
 use ff::PrimeField;
 use ledger_device_sdk::ecc::{CurvesId, math::EcPoint};
-use pasta_curves::pallas;
+use pasta_curves::{arithmetic::CurveAffine, group::{Curve, Group}, pallas};
 
 use crate::{Error, bytes::reverse_copy};
+use crate::redpallas::{point_from_sdk_point, projective_point};
 
 /// Number of bits of each message piece in `SinsemillaHashToPoint`.
 pub const K: usize = 10;
@@ -14417,14 +14418,14 @@ pub fn sinsemilla_short_commit(
     debug_assert!(message.len() <= K * C);
 
     let commitment = sinsemilla_commit(domain, message, randomness)?;
-    extract_p_bottom(commitment)
+    Ok(extract_x_from_pallas_point(commitment))
 }
 
 pub(crate) fn sinsemilla_short_commit_point(
     domain: &str,
     message: &[bool],
     randomness: &pallas::Scalar,
-) -> Result<Option<EcPoint>, Error> {
+) -> Result<Option<pallas::Point>, Error> {
     debug_assert!(message.len() <= K * C);
 
     sinsemilla_commit(domain, message, randomness)
@@ -14434,19 +14435,32 @@ fn sinsemilla_commit(
     domain: &str,
     message: &[bool],
     randomness: &pallas::Scalar,
-) -> Result<Option<EcPoint>, Error> {
+) -> Result<Option<pallas::Point>, Error> {
     let (q_generator, r_generator) = commit_domain_generators(domain)?;
-    let q = point_from_affine_coordinates(&q_generator)?;
-    let hash = hash_to_point(&q, message)?;
+
+    // Convert q to a pure-Rust pallas::Point immediately after creation so that
+    // the EcPoint (2 Bn slots) is freed before the hash loop begins. The loop
+    // accumulator then uses zero Bn slots for all its additions.
+    let q: pallas::Point = {
+        let q_ec = point_from_affine_coordinates(&q_generator)?;
+        point_from_sdk_point(&q_ec)?
+    };
+
+    let hash = hash_to_point(q, message);
 
     let Some(hash) = hash else {
         return Ok(None);
     };
 
-    let mut blinding = point_from_affine_coordinates(&r_generator)?;
-    blinding.rnd_scalarmul(&scalar_bytes_be(randomness))?;
+    // The blinding EcPoint is the only SDK allocation active after the loop.
+    // It is converted and dropped before the final addition, keeping peak usage at 2 slots.
+    let blinding: pallas::Point = {
+        let mut blinding_ec = point_from_affine_coordinates(&r_generator)?;
+        blinding_ec.rnd_scalarmul(&scalar_bytes_be(randomness))?;
+        point_from_sdk_point(&blinding_ec)?
+    };
 
-    Ok(Some(point_add(&hash, &blinding)?))
+    Ok(Some(hash + blinding))
 }
 
 fn commit_domain_generators(domain: &str) -> Result<(AffineCoordinates, AffineCoordinates), Error> {
@@ -14461,20 +14475,41 @@ fn commit_domain_generators(domain: &str) -> Result<(AffineCoordinates, AffineCo
     }
 }
 
-fn hash_to_point(q: &EcPoint, message: &[bool]) -> Result<Option<EcPoint>, Error> {
-    let mut acc = Some(clone_point(q)?);
+fn hash_to_point(q: pallas::Point, message: &[bool]) -> Option<pallas::Point> {
+    // All additions use pure-Rust pallas::Point arithmetic: zero Bn slots in the loop.
+    let mut acc: Option<pallas::Point> = Some(q);
     let chunks = message.len().saturating_add(K - 1) / K;
 
     for chunk_index in 0..chunks {
         let start = chunk_index * K;
         let end = core::cmp::min(start + K, message.len());
-        let s_chunk = point_from_s_index(chunk_to_index(&message[start..end]))?;
 
-        let step = incomplete_add(acc.as_ref(), Some(&s_chunk))?;
-        acc = incomplete_add(step.as_ref(), acc.as_ref())?;
+        let acc_val = acc?;
+        let s = pasta_point_from_s_index(chunk_to_index(&message[start..end]));
+        let step = pallas_incomplete_add(acc_val, s)?;
+        acc = pallas_incomplete_add(step, acc_val);
     }
 
-    Ok(acc)
+    acc
+}
+
+// Converts a SINSEMILLA_S table entry (already a pallas::Base affine coordinate pair)
+// into a projective pallas::Point. Uses zero Bn slots — pure Rust only.
+fn pasta_point_from_s_index(index: usize) -> pallas::Point {
+    let (x, y) = SINSEMILLA_S[index];
+    projective_point(x, y, pallas::Base::one())
+}
+
+// Sinsemilla incomplete addition: returns None for the identity or exceptional cases
+// (equal or negated inputs), which signal a hash collision as required by the spec.
+fn pallas_incomplete_add(lhs: pallas::Point, rhs: pallas::Point) -> Option<pallas::Point> {
+    if bool::from(lhs.is_identity()) || bool::from(rhs.is_identity()) {
+        return None;
+    }
+    if lhs == rhs || lhs == -rhs {
+        return None;
+    }
+    Some(lhs + rhs)
 }
 
 fn chunk_to_index(chunk: &[bool]) -> usize {
@@ -14489,48 +14524,26 @@ fn lebs2ip_k(bits: &[bool; K]) -> u32 {
         .fold(0u32, |acc, (i, bit)| acc + if *bit { 1 << i } else { 0 })
 }
 
-fn incomplete_add(lhs: Option<&EcPoint>, rhs: Option<&EcPoint>) -> Result<Option<EcPoint>, Error> {
-    let (Some(lhs), Some(rhs)) = (lhs, rhs) else {
-        return Ok(None);
-    };
 
-    if lhs.is_at_infinity()? || rhs.is_at_infinity()? {
-        return Ok(None);
+// Extracts the x-coordinate (ExtractP) from an optional pallas::Point.
+// Returns Some(Base::zero()) for the identity point, None when the input is None.
+fn extract_x_from_pallas_point(point: Option<pallas::Point>) -> Option<pallas::Base> {
+    let point = point?;
+    if bool::from(point.is_identity()) {
+        return Some(pallas::Base::zero());
     }
-
-    if lhs.cmp(rhs)? {
-        return Ok(None);
-    }
-
-    let mut neg_rhs = clone_point(rhs)?;
-    neg_rhs.neg()?;
-    if lhs.cmp(&neg_rhs)? {
-        return Ok(None);
-    }
-
-    Ok(Some(point_add(lhs, rhs)?))
+    let affine = point.to_affine();
+    Option::from(affine.coordinates().map(|c| *c.x()))
 }
 
-fn extract_p_bottom(point: Option<EcPoint>) -> Result<Option<pallas::Base>, Error> {
-    let Some(point) = point else {
-        return Ok(None);
-    };
-
-    extract_p(&point).map(Some)
-}
-
-pub(crate) fn extract_p(point: &EcPoint) -> Result<pallas::Base, Error> {
-    if point.is_at_infinity()? {
-        return Ok(pallas::Base::zero());
+pub(crate) fn extract_p_pallas(point: &pallas::Point) -> pallas::Base {
+    if bool::from(point.is_identity()) {
+        return pallas::Base::zero();
     }
-
-    point_x(point)
+    let affine = point.to_affine();
+    Option::from(affine.coordinates().map(|c| *c.x())).unwrap_or_else(pallas::Base::zero)
 }
 
-fn point_from_s_index(index: usize) -> Result<EcPoint, Error> {
-    let (x, y) = &SINSEMILLA_S[index];
-    point_from_affine_repr(&x.to_repr(), &y.to_repr())
-}
 
 fn point_from_affine_coordinates(coords: &AffineCoordinates) -> Result<EcPoint, Error> {
     point_from_affine_repr(&coords.0, &coords.1)
@@ -14547,31 +14560,6 @@ fn point_from_affine_repr(x_le: &[u8; 32], y_le: &[u8; 32]) -> Result<EcPoint, E
     Ok(point)
 }
 
-fn clone_point(point: &EcPoint) -> Result<EcPoint, Error> {
-    let mut x_be = [0u8; 32];
-    let mut y_be = [0u8; 32];
-    point.export(&mut x_be, &mut y_be)?;
-
-    let mut clone = EcPoint::new(CurvesId::Pallas)?;
-    clone.init(&x_be, &y_be)?;
-    Ok(clone)
-}
-
-fn point_add(lhs: &EcPoint, rhs: &EcPoint) -> Result<EcPoint, Error> {
-    let mut sum = EcPoint::new(CurvesId::Pallas)?;
-    sum.add(lhs, rhs)?;
-    Ok(sum)
-}
-
-fn point_x(point: &EcPoint) -> Result<pallas::Base, Error> {
-    let mut x_be = [0u8; 32];
-    let mut y_be = [0u8; 32];
-    point.export(&mut x_be, &mut y_be)?;
-
-    let mut x_le = [0u8; 32];
-    reverse_copy(&mut x_le, &x_be);
-    crate::pallas_base_from_repr(x_le)
-}
 
 fn scalar_bytes_be(scalar: &pallas::Scalar) -> [u8; 32] {
     let repr_le = scalar.to_repr();

--- a/src/parser/pczt.rs
+++ b/src/parser/pczt.rs
@@ -48,7 +48,7 @@ use crate::utils::{
     extended_public_key::ExtendedPublicKey,
     hashers::ToHash160,
 };
-use crate::zip32::{OrchardFvk, derive_orchard_ask, derive_orchard_fvk, orchard_network};
+use crate::zip32::{OrchardAsk, OrchardFvk, derive_orchard_fvk, derive_orchard_fvk_and_ask, orchard_network};
 
 use super::reader::{ByteReader, ReadBytesExt};
 use super::{ParserError, finalize_and_log_hash, ok};

--- a/src/parser/pczt/orchard.rs
+++ b/src/parser/pczt/orchard.rs
@@ -942,7 +942,7 @@ impl PcztParser {
         Ok(())
     }
 
-    fn verify_current_orchard_rk(&self, path: &Bip32Path) -> Result<(), ParserError> {
+    fn verify_current_orchard_rk(&self, ask: &OrchardAsk) -> Result<(), ParserError> {
         let alpha = self
             .current_orchard_alpha
             .ok_or_else(|| ParserError::from_sw(AppSW::BadState))?;
@@ -950,7 +950,6 @@ impl PcztParser {
         let alpha = ledger_zcash_crypto::pallas_scalar_from_repr(alpha)
             .map_err(|_| ParserError::from_str("Bad PCZT orchard alpha"))?;
 
-        let ask = ok!(derive_orchard_ask(path));
         let randomized_ask = ask
             .randomize_ledger(&alpha)
             .map_err(|_| ParserError::from_sw(AppSW::TechnicalProblem))?;
@@ -1067,11 +1066,18 @@ impl PcztParser {
             self.orchard_action_parsed_count, path
         );
 
-        let orchard_fvk = ok!(derive_orchard_fvk(&path));
-        // Dummy spends (spend_value == 0) use a throwaway key unrelated to the device seed;
-        // rk verification only applies to real spends the device will sign.
-        if self.current_orchard_spend_value != 0 {
-            self.verify_current_orchard_rk(&path)?;
+        // For real spends, derive FVK and ASK from a single SK derivation.
+        // Calling zip32_orchard_derive separately for FVK and ASK exhausts the BN pool,
+        // so both are derived from the same OrchardSk here.
+        let (orchard_fvk, ask_for_rk) = if self.current_orchard_spend_value != 0 {
+            let (fvk, ask) = ok!(derive_orchard_fvk_and_ask(&path));
+            (fvk, Some(ask))
+        } else {
+            // Dummy spend: throwaway key, rk check skipped.
+            (ok!(derive_orchard_fvk(&path)), None)
+        };
+        if let Some(ref ask) = ask_for_rk {
+            self.verify_current_orchard_rk(ask)?;
         }
         let network = orchard_network(&path);
         ctx.tx_info.orchard_decipher_keys =

--- a/src/parser/pczt/orchard.rs
+++ b/src/parser/pczt/orchard.rs
@@ -1064,7 +1064,11 @@ impl PcztParser {
         );
 
         let orchard_fvk = ok!(derive_orchard_fvk(&path));
-        self.verify_current_orchard_rk(&path)?;
+        // Dummy spends (spend_value == 0) use a throwaway key unrelated to the device seed;
+        // rk verification only applies to real spends the device will sign.
+        if self.current_orchard_spend_value != 0 {
+            self.verify_current_orchard_rk(&path)?;
+        }
         let network = orchard_network(&path);
         ctx.tx_info.orchard_decipher_keys =
             Some(ok!(OrchardDecipherKeys::from_fvk(&orchard_fvk, network)));

--- a/src/parser/pczt/orchard.rs
+++ b/src/parser/pczt/orchard.rs
@@ -493,11 +493,15 @@ impl PcztParser {
         let note_ciphertext = self.current_orchard_note_ciphertext(out_ciphertext)?;
 
         self.verify_current_orchard_cv_net()?;
-        let orchard_fvk = self
-            .current_orchard_fvk
-            .as_ref()
-            .ok_or_else(|| ParserError::from_sw(AppSW::BadState))?;
-        self.verify_current_orchard_spend_nullifier(orchard_fvk)?;
+        // Dummy spends (spend_value == 0) use a throwaway key; recipient membership
+        // and nullifier checks only apply to real spends the device will sign.
+        if self.current_orchard_spend_value != 0 {
+            let orchard_fvk = self
+                .current_orchard_fvk
+                .as_ref()
+                .ok_or_else(|| ParserError::from_sw(AppSW::BadState))?;
+            self.verify_current_orchard_spend_nullifier(orchard_fvk)?;
+        }
         self.validate_current_orchard_output(ctx, &note_ciphertext)?;
 
         self.orchard_spend_value_sum = self

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -1,4 +1,4 @@
-use orchard::keys::{SpendAuthorizingKey as OrchardAsk, SpendingKey as OrchardSk};
+use orchard::keys::SpendingKey as OrchardSk;
 use zcash_protocol::consensus::NetworkType;
 
 use ledger_device_sdk::ecc::Pallas;
@@ -10,6 +10,7 @@ use crate::utils::extended_public_key::ExtendedPublicKey;
 use crate::{AppSW, utils::bip32_path::Bip32Path};
 
 pub use orchard::keys::FullViewingKey as OrchardFvk;
+pub use orchard::keys::SpendAuthorizingKey as OrchardAsk;
 
 pub fn map_ledger_crypto_error(err: ledger_zcash_crypto::Error) -> AppSW {
     match err {
@@ -78,4 +79,17 @@ pub fn derive_orchard_fvk(path: &Bip32Path) -> Result<OrchardFvk, AppSW> {
     info!("Orchard FVK: {}", HexSlice(&orchard_fvk.to_bytes()));
 
     Ok(orchard_fvk)
+}
+
+// Derives both FVK and ASK from a single zip32_orchard_derive call.
+// Use instead of calling derive_orchard_fvk + derive_orchard_ask separately,
+// as two consecutive zip32_orchard_derive calls exhaust the BN pool.
+pub fn derive_orchard_fvk_and_ask(
+    path: &Bip32Path,
+) -> Result<(OrchardFvk, OrchardAsk), AppSW> {
+    let sk = derive_orchard_sk(path)?;
+    let fvk = OrchardFvk::ledger_try_from(&sk).map_err(map_ledger_crypto_error)?;
+    info!("Orchard FVK: {}", HexSlice(&fvk.to_bytes()));
+    let ask = OrchardAsk::ledger_try_from(&sk).map_err(map_ledger_crypto_error)?;
+    Ok((fvk, ask))
 }


### PR DESCRIPTION
Different issues have been found.

**Issue #1:**

Root cause: Bn allocator exhaustion in spendauth_randomized_signing_key

Where it fails: ledger_zcash_crypto/src/redpallas.rs:214

Why it fails: spendauth_randomized_signing_key holds 4 Bn objects alive when it tail-calls spendauth_signing_key. That inner call immediately allocates 2 more Bn objects (in canonical_scalar_bytes_be), pushing the simultaneous count to 6. The Ledger SDK's cx_bn pool is exhausted - Bn::alloc returns a CxError, which bubbles up as ledger_zcash_crypto::Error::Cx(_), which verify_current_orchard_rk maps uniformly to AppSW::TechnicalProblem -> 0x6F00.

This code path was never exercised before commit 88af7a7 ("Add Orchard rk verification", June 17 2026). The getFullViewingKey flow that works fine never calls spendauth_randomized_signing_key, so the pool exhaustion was not caught by existing tests.

Issue #2:

The 6f00 in v3.8.1 is from a DIFFERENT root cause than the original Bn fix — it's EcPoint pool exhaustion in the Sinsemilla hash_to_point loop used by OrchardDecipherKeys::from_fvk → to_ivk_ledger → IVK derivation.

Root cause: In hash_to_point, during the second incomplete_add per loop iteration, up to 6 concurrent EcPoints exist simultaneously (each using 2 Bn slots = 12 total), exceeding the 8-slot Bn pool:
- q (alive in sinsemilla_commit): 2 slots
- old acc: 2 slots
- step (result of first incomplete_add): 2 slots
- s_chunk (still alive in loop body): 2 slots
- neg_rhs (cloned inside incomplete_add): 2 slots
- sum (from point_add): 2 slots → 12 total → CxError::MemoryFull → 6f00

Issue #3:

The Bn pool has exactly 5 slots on Flex, but point_add in Sinsemilla needs 6 (lhs=2 + rhs=2 + sum=2). Fix #2 reduced from 12 to 6 but the pool is 5. The fix is to perform the Sinsemilla loop additions in pure Rust via pallas::Point arithmetic instead of SDK EcPoints. Let me check the pasta_curves API available in the vendor.

Root cause: The Flex cx_bn pool has exactly 5 slots for 32-byte (Pallas field) operations. Sinsemilla's hash_to_point loop needed 6: accumulator EcPoint (2 slots) + s_chunk EcPoint (2 slots) + point_add sum allocation (2 more). That 6th alloc failed → CxError → AppSW::TechnicalProblem → 6f00.



# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [x] App update process has been followed <!-- See comment below -->
- [x] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

<!-- Make sure you followed the process described in https://developers.ledger.com/docs/device-app/deliver/maintenance before opening your Pull Request.
Don't hesitate to contact us directly on Discord if you have any questions ! https://developers.ledger.com/discord -->

https://ledgerhq.atlassian.net/browse/LIVE-34694